### PR TITLE
chore: update vLLM image to latest rhoai-2.24-cuda

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,7 +51,7 @@ servingRuntime:
   recommendedAccelerators: '["nvidia.com/gpu"]'
   templateName: vllm-cuda-runtime
   container:
-    image: 'quay.io/modh/vllm@sha256:79e1f24bba1d3e694f47f66ba9f8184e70310a10b77bf11c0febd0c926234950'
+    image: 'quay.io/modh/vllm@sha256:3abf5abad8c4f1acd4c15f396856c09f4e93070ee70c8a82690ec5dd8004856e'
     resources:
       limits:
         cpu: '2'


### PR DESCRIPTION
## Summary
This PR updates the vLLM image in the Helm chart to point to the latest `rhoai-2.24-cuda` version with SHA digest:

quay.io/modh/vllm@sha256:3abf5abad8c4458fe8f8d2237cb0ff0c05300e35283e2ef121b20f9ee3c1c78c

## Notes
- Verified the digest matches quay tag: `rhoai-2.24-cuda`
- No other changes were made